### PR TITLE
Remove building stages from build-only

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -249,7 +249,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer -i python:3.13-alpine --cache-dir=/cache/images"
+      - /kaniko/warmer -i python:3.13-alpine --cache-dir=/cache/images
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -164,9 +164,6 @@ steps:
         --context="." 
         --dockerfile="local_graph_service/Dockerfile"
         --compressed-caching=false
-        --cache=true
-        --cache-copy-layers=false
-        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -300,6 +300,7 @@ volumes:
 trigger:
   branch:
     - main
+    - exp/cicd
   event:
     include:
       - promote
@@ -307,7 +308,6 @@ trigger:
       # - push
   target:
     - production
-    - exp/cicd
 
 
 ---

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -249,7 +249,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer --dockerfile=web_service/Dockerfile --cache-dir=/cache/images"
+      - "/kaniko/warmer -i python:3.13-alpine --cache-dir=/cache/images"
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -94,8 +94,7 @@ steps:
         --compressed-caching=false
         --cache=true
         --cache-copy-layers=false
-        --cache-run-layers=false
-        --no-push-cache
+        --cache-run-layers=true
         --cache-dir=/cache/images
 
   - name: build-push-web
@@ -130,8 +129,7 @@ steps:
         --compressed-caching=false
         --cache=true
         --cache-copy-layers=false
-        --cache-run-layers=false
-        --no-push-cache
+        --cache-run-layers=true
         --cache-dir=/cache/images
 
   - name: build-push-remote-transcription
@@ -166,8 +164,7 @@ steps:
         --compressed-caching=false
         --cache=true
         --cache-copy-layers=false
-        --cache-run-layers=false
-        --no-push-cache
+        --cache-run-layers=true
         --cache-dir=/cache/images
 
   - name: build-push-remote-language
@@ -202,8 +199,7 @@ steps:
         --compressed-caching=false
         --cache=true
         --cache-copy-layers=false
-        --cache-run-layers=false
-        --no-push-cache
+        --cache-run-layers=true
         --cache-dir=/cache/images
 
   - name: build-push-local-graph
@@ -238,8 +234,7 @@ steps:
         --compressed-caching=false
         --cache=true
         --cache-copy-layers=false
-        --cache-run-layers=false
-        --no-push-cache
+        --cache-run-layers=true
         --cache-dir=/cache/images
 
   - name: clone-infra

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -241,6 +241,8 @@ steps:
       - name: warmer-cache
         path: /cache
     commands:
+      - echo 12345
+      - sleep 1h
       - /kaniko/warmer 
         --dockerfile="api_service/Dockerfile"
         --cache-dir="/cache/images"

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -241,7 +241,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile="api_service/Dockerfile" --cache-dir="/cache/images"
+      - /kaniko/warmer --dockerfile=api_service/Dockerfile --cache-dir=/cache/images
 
   - name: image-warmer-web
     image: gcr.io/kaniko-project/warmer:latest
@@ -249,7 +249,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile="web_service/Dockerfile" --cache-dir="/cache/images"
+      - /kaniko/warmer --dockerfile=web_service/Dockerfile --cache-dir=/cache/images
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest
@@ -257,7 +257,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile="remote_transcription_service/Dockerfile" --cache-dir="/cache/images"
+      - /kaniko/warmer --dockerfile=remote_transcription_service/Dockerfile --cache-dir=/cache/images
 
   - name: image-warmer-remote-language
     image: gcr.io/kaniko-project/warmer:latest
@@ -265,7 +265,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile="remote_language_service/Dockerfile" --cache-dir="/cache/images"
+      - /kaniko/warmer --dockerfile=remote_language_service/Dockerfile --cache-dir=/cache/images
 
   - name: image-warmer-local-graph
     image: gcr.io/kaniko-project/warmer:latest
@@ -273,7 +273,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile="local_graph_service/Dockerfile" --cache-dir="/cache/images"
+      - /kaniko/warmer --dockerfile=local_graph_service/Dockerfile --cache-dir=/cache/images
 
   - name: build-no-push-api
     image: gcr.io/kaniko-project/executor:debug

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -103,7 +103,6 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-web
-      - build-push-api
     environment:
       USERNAME:
         from_secret: registry_username
@@ -141,7 +140,6 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-remote-transcription
-      - build-push-web
     environment:
       USERNAME:
         from_secret: registry_username
@@ -179,7 +177,6 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-remote-language
-      - build-push-remote-transcription
     environment:
       USERNAME:
         from_secret: registry_username
@@ -217,7 +214,6 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-local-graph
-      - build-push-remote-language
     environment:
       USERNAME:
         from_secret: registry_username
@@ -291,24 +287,24 @@ steps:
         echo Updating Kustomize image for local graph: "$LOCAL_GRAPH_IMAGE_NAME"
       - kustomize edit set image nvideo-local-graph-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
 
-  - name: push-infra-changes
-    image: alpine/git
-    depends_on:
-      - build-push-api
-      - build-push-web
-      - build-push-remote-transcription
-      - build-push-remote-language
-      - build-push-local-graph
-      - clone-infra
-      - update-infra
-    commands:
-      - cd nvideo-infra
-      - git checkout main
-      - git config user.email "drone@deeplerg.dev"
-      - git config user.name "Drone"
-      - git add .
-      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
-      - git push
+#  - name: push-infra-changes
+#    image: alpine/git
+#    depends_on:
+#      - build-push-api
+#      - build-push-web
+#      - build-push-remote-transcription
+#      - build-push-remote-language
+#      - build-push-local-graph
+#      - clone-infra
+#      - update-infra
+#    commands:
+#      - cd nvideo-infra
+#      - git checkout main
+#      - git config user.email "drone@deeplerg.dev"
+#      - git config user.name "Drone"
+#      - git add .
+#      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
+#      - git push
 
 volumes:
   - name: warmer-cache
@@ -318,6 +314,7 @@ volumes:
 trigger:
   branch:
     - main
+    - exp/cicd
   event:
     include:
       - promote
@@ -386,6 +383,7 @@ steps:
 trigger:
   branch:
     - main
+    - exp/cicd
   event:
     - pull_request
     - push

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -240,9 +240,8 @@ steps:
     volumes:
       - name: warmer-cache
         path: /cache
-    entrypoint:
-      - /kaniko/warmer
     command:
+      - /kaniko/warmer
       - --dockerfile=api_service/Dockerfile
       - --cache-dir=/cache/images
 

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -251,7 +251,9 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer --dockerfile=web_service/Dockerfile --cache-dir=/cache/images"
+      - /kaniko/warmer
+      - --dockerfile=web_service/Dockerfile
+      - --cache-dir=/cache/images
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest
@@ -259,7 +261,9 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer --dockerfile=remote_transcription_service/Dockerfile --cache-dir=/cache/images"
+      - /kaniko/warmer
+      - --dockerfile=remote_transcription_service/Dockerfile
+      - --cache-dir=/cache/images
 
   - name: image-warmer-remote-language
     image: gcr.io/kaniko-project/warmer:latest
@@ -267,7 +271,9 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer --dockerfile=remote_language_service/Dockerfile --cache-dir=/cache/images"
+      - /kaniko/warmer
+      - --dockerfile=remote_language_service/Dockerfile
+      - --cache-dir=/cache/images
 
   - name: image-warmer-local-graph
     image: gcr.io/kaniko-project/warmer:latest
@@ -275,7 +281,9 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer --dockerfile=local_graph_service/Dockerfile --cache-dir=/cache/images"
+      - /kaniko/warmer
+      - --dockerfile=local_graph_service/Dockerfile
+      - --cache-dir=/cache/images
 
   - name: build-no-push-api
     image: gcr.io/kaniko-project/executor:debug

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -164,6 +164,9 @@ steps:
         --context="." 
         --dockerfile="local_graph_service/Dockerfile"
         --compressed-caching=false
+        --cache=true
+        --cache-copy-layers=false
+        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -16,6 +16,8 @@ steps:
 
   - name: image-warmer-web
     image: gcr.io/kaniko-project/warmer:latest
+    depends_on:
+      - image-warmer-api
     volumes:
       - name: warmer-cache
         path: /cache
@@ -26,6 +28,8 @@ steps:
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest
+    depends_on:
+      - image-warmer-web
     volumes:
       - name: warmer-cache
         path: /cache
@@ -36,6 +40,8 @@ steps:
 
   - name: image-warmer-remote-language
     image: gcr.io/kaniko-project/warmer:latest
+    depends_on:
+      - image-warmer-remote-transcription
     volumes:
       - name: warmer-cache
         path: /cache
@@ -46,6 +52,8 @@ steps:
 
   - name: image-warmer-local-graph
     image: gcr.io/kaniko-project/warmer:latest
+    depends_on:
+      - image-warmer-remote-language
     volumes:
       - name: warmer-cache
         path: /cache

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -103,6 +103,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-web
+      - build-push-api
     environment:
       USERNAME:
         from_secret: registry_username
@@ -140,6 +141,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-remote-transcription
+      - build-push-web
     environment:
       USERNAME:
         from_secret: registry_username
@@ -177,6 +179,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-remote-language
+      - build-push-remote-transcription
     environment:
       USERNAME:
         from_secret: registry_username
@@ -214,6 +217,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-local-graph
+      - build-push-remote-language
     environment:
       USERNAME:
         from_secret: registry_username
@@ -287,24 +291,24 @@ steps:
         echo Updating Kustomize image for local graph: "$LOCAL_GRAPH_IMAGE_NAME"
       - kustomize edit set image nvideo-local-graph-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
 
-#  - name: push-infra-changes
-#    image: alpine/git
-#    depends_on:
-#      - build-push-api
-#      - build-push-web
-#      - build-push-remote-transcription
-#      - build-push-remote-language
-#      - build-push-local-graph
-#      - clone-infra
-#      - update-infra
-#    commands:
-#      - cd nvideo-infra
-#      - git checkout main
-#      - git config user.email "drone@deeplerg.dev"
-#      - git config user.name "Drone"
-#      - git add .
-#      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
-#      - git push
+  - name: push-infra-changes
+    image: alpine/git
+    depends_on:
+      - build-push-api
+      - build-push-web
+      - build-push-remote-transcription
+      - build-push-remote-language
+      - build-push-local-graph
+      - clone-infra
+      - update-infra
+    commands:
+      - cd nvideo-infra
+      - git checkout main
+      - git config user.email "drone@deeplerg.dev"
+      - git config user.name "Drone"
+      - git add .
+      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
+      - git push
 
 volumes:
   - name: warmer-cache
@@ -314,7 +318,6 @@ volumes:
 trigger:
   branch:
     - main
-    - exp/cicd
   event:
     include:
       - promote
@@ -383,7 +386,6 @@ steps:
 trigger:
   branch:
     - main
-    - exp/cicd
   event:
     - pull_request
     - push

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -241,7 +241,9 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - "/kaniko/warmer --dockerfile=api_service/Dockerfile --cache-dir=/cache/images"
+      - /kaniko/warmer
+      - --dockerfile=api_service/Dockerfile
+      - --cache-dir=/cache/images
 
   - name: image-warmer-web
     image: gcr.io/kaniko-project/warmer:latest
@@ -249,7 +251,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer -i python:3.13-alpine --cache-dir=/cache/images
+      - "/kaniko/warmer --dockerfile=web_service/Dockerfile --cache-dir=/cache/images"
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -96,6 +96,8 @@ steps:
         --cache-copy-layers=false
         --cache-run-layers=true
         --cache-dir=/cache/images
+        --image-fs-extract-retry=5
+        --image-download-retry=5
 
   - name: build-push-web
     image: gcr.io/kaniko-project/executor:debug
@@ -131,6 +133,8 @@ steps:
         --cache-copy-layers=false
         --cache-run-layers=true
         --cache-dir=/cache/images
+        --image-fs-extract-retry=5
+        --image-download-retry=5
 
   - name: build-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
@@ -166,6 +170,8 @@ steps:
         --cache-copy-layers=false
         --cache-run-layers=true
         --cache-dir=/cache/images
+        --image-fs-extract-retry=5
+        --image-download-retry=5
 
   - name: build-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
@@ -201,6 +207,8 @@ steps:
         --cache-copy-layers=false
         --cache-run-layers=true
         --cache-dir=/cache/images
+        --image-fs-extract-retry=5
+        --image-download-retry=5
 
   - name: build-push-local-graph
     image: gcr.io/kaniko-project/executor:debug
@@ -236,6 +244,8 @@ steps:
         --cache-copy-layers=false
         --cache-run-layers=true
         --cache-dir=/cache/images
+        --image-fs-extract-retry=5
+        --image-download-retry=5
 
   - name: clone-infra
     image: alpine/git

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -240,7 +240,8 @@ steps:
     volumes:
       - name: warmer-cache
         path: /cache
-    entrypoint: /kaniko/warmer
+    entrypoint:
+      - /kaniko/warmer
     command:
       - --dockerfile=api_service/Dockerfile
       - --cache-dir=/cache/images

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -4,7 +4,7 @@ type: kubernetes
 name: prod-build-push
 
 steps:
-  - name: image-warmer-api
+  - name: image-warmer
     image: gcr.io/kaniko-project/warmer:latest
     volumes:
       - name: warmer-cache
@@ -12,45 +12,9 @@ steps:
     command:
       - /kaniko/warmer
       - --dockerfile=api_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-web
-    image: gcr.io/kaniko-project/warmer:latest
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
       - --dockerfile=web_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-remote-transcription
-    image: gcr.io/kaniko-project/warmer:latest
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
       - --dockerfile=remote_transcription_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-remote-language
-    image: gcr.io/kaniko-project/warmer:latest
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
       - --dockerfile=remote_language_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-local-graph
-    image: gcr.io/kaniko-project/warmer:latest
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
       - --dockerfile=local_graph_service/Dockerfile
       - --cache-dir=/cache/images
 

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -250,7 +250,6 @@ steps:
 trigger:
   branch:
     - main
-    - exp/cicd
   event:
     - pull_request
     - push

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -230,45 +230,45 @@ type: kubernetes
 name: prod-build-only
 
 steps:
-  - name: build-no-push-api
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building API service"
-      - /kaniko/executor 
-        --no-push 
-        --context="." 
-        --dockerfile="api_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-no-push-web
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building Web service"
-      - /kaniko/executor 
-        --no-push 
-        --context="." 
-        --dockerfile="web_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-no-push-remote-transcription
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building remote transcription service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="remote_transcription_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-no-push-remote-language
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building remote language service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="remote_language_service/Dockerfile"
-        --compressed-caching=false
+#  - name: build-no-push-api
+#    image: gcr.io/kaniko-project/executor:debug
+#    commands:
+#      - echo "Building API service"
+#      - /kaniko/executor
+#        --no-push
+#        --context="."
+#        --dockerfile="api_service/Dockerfile"
+#        --compressed-caching=false
+#
+#  - name: build-no-push-web
+#    image: gcr.io/kaniko-project/executor:debug
+#    commands:
+#      - echo "Building Web service"
+#      - /kaniko/executor
+#        --no-push
+#        --context="."
+#        --dockerfile="web_service/Dockerfile"
+#        --compressed-caching=false
+#
+#  - name: build-no-push-remote-transcription
+#    image: gcr.io/kaniko-project/executor:debug
+#    commands:
+#      - echo "Building remote transcription service"
+#      - /kaniko/executor
+#        --no-push
+#        --context="."
+#        --dockerfile="remote_transcription_service/Dockerfile"
+#        --compressed-caching=false
+#
+#  - name: build-no-push-remote-language
+#    image: gcr.io/kaniko-project/executor:debug
+#    commands:
+#      - echo "Building remote language service"
+#      - /kaniko/executor
+#        --no-push
+#        --context="."
+#        --dockerfile="remote_language_service/Dockerfile"
+#        --compressed-caching=false
 
   - name: build-no-push-local-graph
     image: gcr.io/kaniko-project/executor:debug

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -207,29 +207,28 @@ steps:
         echo Updating Kustomize image for local graph: "$LOCAL_GRAPH_IMAGE_NAME"
       - kustomize edit set image nvideo-local-graph-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
 
-#  - name: push-infra-changes
-#    image: alpine/git
-#    depends_on:
-#      - build-push-api
-#      - build-push-web
-#      - build-push-remote-transcription
-#      - build-push-remote-language
-#      - build-push-local-graph
-#      - clone-infra
-#      - update-infra
-#    commands:
-#      - cd nvideo-infra
-#      - git checkout main
-#      - git config user.email "drone@deeplerg.dev"
-#      - git config user.name "Drone"
-#      - git add .
-#      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
-#      - git push
+  - name: push-infra-changes
+    image: alpine/git
+    depends_on:
+      - build-push-api
+      - build-push-web
+      - build-push-remote-transcription
+      - build-push-remote-language
+      - build-push-local-graph
+      - clone-infra
+      - update-infra
+    commands:
+      - cd nvideo-infra
+      - git checkout main
+      - git config user.email "drone@deeplerg.dev"
+      - git config user.name "Drone"
+      - git add .
+      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
+      - git push
 
 trigger:
   branch:
     - main
-    - exp/cicd
   event:
     include:
       - promote
@@ -298,7 +297,6 @@ steps:
 trigger:
   branch:
     - main
-    - exp/cicd
   event:
     - pull_request
     - push

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -137,8 +137,6 @@ steps:
   - name: build-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - build-push-api
-      - build-push-web
       - image-warmer-remote-transcription
     environment:
       USERNAME:
@@ -175,8 +173,6 @@ steps:
   - name: build-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - build-push-api
-      - build-push-web
       - image-warmer-remote-language
     environment:
       USERNAME:
@@ -213,8 +209,6 @@ steps:
   - name: build-push-local-graph
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - build-push-api
-      - build-push-web
       - image-warmer-local-graph
     environment:
       USERNAME:

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -235,8 +235,33 @@ type: kubernetes
 name: prod-build-only
 
 steps:
+  - name: image-warmer
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    commands:
+      - /kaniko/warmer 
+        --dockerfile="api_service/Dockerfile"
+        --cache-dir="/cache/images"
+      - /kaniko/warmer 
+        --dockerfile="web_service/Dockerfile"
+        --cache-dir="/cache/images"
+      - /kaniko/warmer 
+        --dockerfile="remote_transcription_service/Dockerfile"
+        --cache-dir="/cache/images"
+      - /kaniko/warmer 
+        --dockerfile="remote_language_service/Dockerfile"
+        --cache-dir="/cache/images"
+      - /kaniko/warmer 
+        --dockerfile="local_graph_service/Dockerfile"
+        --cache-dir="/cache/images"
+
   - name: build-no-push-api
     image: gcr.io/kaniko-project/executor:debug
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - echo "Building API service"
       - /kaniko/executor
@@ -244,9 +269,17 @@ steps:
         --context="."
         --dockerfile="api_service/Dockerfile"
         --compressed-caching=false
+        --cache=true
+        --cache-copy-layers=false
+        --cache-run-layers=false
+        --no-push-cache
+        --cache-dir=/cache/images
 
   - name: build-no-push-web
     image: gcr.io/kaniko-project/executor:debug
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - echo "Building Web service"
       - /kaniko/executor
@@ -254,9 +287,17 @@ steps:
         --context="."
         --dockerfile="web_service/Dockerfile"
         --compressed-caching=false
+        --cache=true
+        --cache-copy-layers=false
+        --cache-run-layers=false
+        --no-push-cache
+        --cache-dir=/cache/images
 
   - name: build-no-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - echo "Building remote transcription service"
       - /kaniko/executor
@@ -264,9 +305,17 @@ steps:
         --context="."
         --dockerfile="remote_transcription_service/Dockerfile"
         --compressed-caching=false
+        --cache=true
+        --cache-copy-layers=false
+        --cache-run-layers=false
+        --no-push-cache
+        --cache-dir=/cache/images
 
   - name: build-no-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - echo "Building remote language service"
       - /kaniko/executor
@@ -274,9 +323,17 @@ steps:
         --context="."
         --dockerfile="remote_language_service/Dockerfile"
         --compressed-caching=false
+        --cache=true
+        --cache-copy-layers=false
+        --cache-run-layers=false
+        --no-push-cache
+        --cache-dir=/cache/images
 
   - name: build-no-push-local-graph
     image: gcr.io/kaniko-project/executor:debug
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - echo "Building local graph service"
       - /kaniko/executor
@@ -284,6 +341,16 @@ steps:
         --context="."
         --dockerfile="local_graph_service/Dockerfile"
         --compressed-caching=false
+        --cache=true
+        --cache-copy-layers=false
+        --cache-run-layers=false
+        --no-push-cache
+        --cache-dir=/cache/images
+
+volumes:
+  - name: warmer-cache
+    claim:
+      name: kaniko-warmer-pvc
 
 trigger:
   branch:

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -103,6 +103,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-web
+      - build-push-api
     environment:
       USERNAME:
         from_secret: registry_username
@@ -140,6 +141,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-remote-transcription
+      - build-push-web
     environment:
       USERNAME:
         from_secret: registry_username
@@ -177,6 +179,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-remote-language
+      - build-push-remote-transcription
     environment:
       USERNAME:
         from_secret: registry_username
@@ -214,6 +217,7 @@ steps:
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
       - image-warmer-local-graph
+      - build-push-remote-language
     environment:
       USERNAME:
         from_secret: registry_username

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -244,59 +244,13 @@ type: kubernetes
 name: prod-build-only
 
 steps:
-  - name: build-no-push-api
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building API service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="api_service/Dockerfile"
-        --compressed-caching=false
 
-  - name: build-no-push-web
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building Web service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="web_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-no-push-remote-transcription
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building remote transcription service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="remote_transcription_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-no-push-remote-language
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building remote language service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="remote_language_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-no-push-local-graph
-    image: gcr.io/kaniko-project/executor:debug
-    commands:
-      - echo "Building local graph service"
-      - /kaniko/executor
-        --no-push
-        --context="."
-        --dockerfile="local_graph_service/Dockerfile"
-        --compressed-caching=false
+# python is an interpreted language. I still want green checks though
 
 trigger:
   branch:
     - main
+    - exp/cicd
   event:
     - pull_request
     - push

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -238,6 +238,7 @@ steps:
         --no-push 
         --context="." 
         --dockerfile="api_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-no-push-web
     image: gcr.io/kaniko-project/executor:debug
@@ -247,6 +248,7 @@ steps:
         --no-push 
         --context="." 
         --dockerfile="web_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-no-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
@@ -256,6 +258,7 @@ steps:
         --no-push
         --context="."
         --dockerfile="remote_transcription_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-no-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
@@ -265,10 +268,12 @@ steps:
         --no-push
         --context="."
         --dockerfile="remote_language_service/Dockerfile"
+        --compressed-caching=false
 
 trigger:
   branch:
     - main
+    - exp/cicd
   event:
     - pull_request
     - push

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -4,237 +4,6 @@ type: kubernetes
 name: prod-build-push
 
 steps:
-  - name: build-push-api
-    image: gcr.io/kaniko-project/executor:debug
-    environment:
-      USERNAME:
-        from_secret: registry_username
-      PASSWORD:
-        from_secret: registry_password
-      REGISTRY:
-        from_secret: registry_address
-    commands:
-      - COMMIT=${DRONE_COMMIT_SHA:0:8}
-      - RAW_BRANCH=${DRONE_BRANCH}
-      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
-      - TAG=$BRANCH-$COMMIT
-      - API_IMAGE_NAME=$REGISTRY/nvideo-api:$TAG
-
-      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
-      - |
-        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
-      - echo $JSON > "/kaniko/.docker/config.json"
-
-      - |
-        echo Building and pushing API service: $API_IMAGE_NAME
-      - /kaniko/executor 
-        --destination="$API_IMAGE_NAME" 
-        --context="." 
-        --dockerfile="api_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-push-web
-    image: gcr.io/kaniko-project/executor:debug
-    environment:
-      USERNAME:
-        from_secret: registry_username
-      PASSWORD:
-        from_secret: registry_password
-      REGISTRY:
-        from_secret: registry_address
-    commands:
-      - COMMIT=${DRONE_COMMIT_SHA:0:8}
-      - RAW_BRANCH=${DRONE_BRANCH}
-      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
-      - TAG=$BRANCH-$COMMIT
-      - WEB_IMAGE_NAME=$REGISTRY/nvideo-web:$TAG
-
-      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
-      - |
-        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
-      - echo $JSON > "/kaniko/.docker/config.json"
-
-      - |
-        echo Building and pushing Web service: "$WEB_IMAGE_NAME"
-      - /kaniko/executor 
-        --destination="$WEB_IMAGE_NAME" 
-        --context="." 
-        --dockerfile="web_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-push-remote-transcription
-    image: gcr.io/kaniko-project/executor:debug
-    depends_on:
-      - build-push-api
-      - build-push-web
-    environment:
-      USERNAME:
-        from_secret: registry_username
-      PASSWORD:
-        from_secret: registry_password
-      REGISTRY:
-        from_secret: registry_address
-    commands:
-      - COMMIT=${DRONE_COMMIT_SHA:0:8}
-      - RAW_BRANCH=${DRONE_BRANCH}
-      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
-      - TAG=$BRANCH-$COMMIT
-      - IMAGE_NAME=$REGISTRY/nvideo-remote-transcription:$TAG
-
-      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
-      - |
-        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
-      - echo $JSON > "/kaniko/.docker/config.json"
-
-      - |
-        echo Building and pushing remote transcription service: "$IMAGE_NAME"
-      - /kaniko/executor 
-        --destination="$IMAGE_NAME" 
-        --context="." 
-        --dockerfile="remote_transcription_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-push-remote-language
-    image: gcr.io/kaniko-project/executor:debug
-    depends_on:
-      - build-push-api
-      - build-push-web
-    environment:
-      USERNAME:
-        from_secret: registry_username
-      PASSWORD:
-        from_secret: registry_password
-      REGISTRY:
-        from_secret: registry_address
-    commands:
-      - COMMIT=${DRONE_COMMIT_SHA:0:8}
-      - RAW_BRANCH=${DRONE_BRANCH}
-      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
-      - TAG=$BRANCH-$COMMIT
-      - IMAGE_NAME=$REGISTRY/nvideo-remote-language:$TAG
-
-      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
-      - |
-        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
-      - echo $JSON > "/kaniko/.docker/config.json"
-
-      - |
-        echo Building and pushing remote language service: "$IMAGE_NAME"
-      - /kaniko/executor 
-        --destination="$IMAGE_NAME" 
-        --context="." 
-        --dockerfile="remote_language_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: build-push-local-graph
-    image: gcr.io/kaniko-project/executor:debug
-    depends_on:
-      - build-push-api
-      - build-push-web
-    environment:
-      USERNAME:
-        from_secret: registry_username
-      PASSWORD:
-        from_secret: registry_password
-      REGISTRY:
-        from_secret: registry_address
-    commands:
-      - COMMIT=${DRONE_COMMIT_SHA:0:8}
-      - RAW_BRANCH=${DRONE_BRANCH}
-      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
-      - TAG=$BRANCH-$COMMIT
-      - IMAGE_NAME=$REGISTRY/nvideo-local-graph:$TAG
-
-      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
-      - |
-        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
-      - echo $JSON > "/kaniko/.docker/config.json"
-
-      - |
-        echo Building and pushing local graph service: "$IMAGE_NAME"
-      - /kaniko/executor 
-        --destination="$IMAGE_NAME" 
-        --context="." 
-        --dockerfile="local_graph_service/Dockerfile"
-        --compressed-caching=false
-
-  - name: clone-infra
-    image: alpine/git
-    commands:
-      - git clone https://github.com/Deeplerg/nvideo-infra
-
-  - name: update-infra
-    image: registry.k8s.io/kustomize/kustomize:v5.0.0
-    depends_on:
-      - clone-infra
-    environment:
-      REGISTRY:
-        from_secret: registry_address
-    commands:
-      - COMMIT=${DRONE_COMMIT_SHA:0:8}
-      - BRANCH=main
-      - TAG=$BRANCH-$COMMIT
-      - API_IMAGE_NAME="$REGISTRY/nvideo-api:$TAG"
-      - WEB_IMAGE_NAME="$REGISTRY/nvideo-web:$TAG"
-      - REMOTE_TRANSCRIPTION_IMAGE_NAME="$REGISTRY/nvideo-remote-transcription:$TAG"
-      - REMOTE_LANGUAGE_IMAGE_NAME="$REGISTRY/nvideo-remote-language:$TAG"
-      - LOCAL_GRAPH_IMAGE_NAME="$REGISTRY/nvideo-local-graph:$TAG"
-
-      - cd nvideo-infra/kustomization/prod
-
-      - |
-        echo Updating Kustomize image for API: "$API_IMAGE_NAME"
-      - kustomize edit set image nvideo-api-image-name-placeholder="$API_IMAGE_NAME"
-      - |
-        echo Updating Kustomize image for Web: "$WEB_IMAGE_NAME"
-      - kustomize edit set image nvideo-web-image-name-placeholder="$WEB_IMAGE_NAME"
-      - |
-        echo Updating Kustomize image for remote transcription: "$REMOTE_TRANSCRIPTION_IMAGE_NAME"
-      - kustomize edit set image nvideo-remote-transcription-image-name-placeholder="$REMOTE_TRANSCRIPTION_IMAGE_NAME"
-      - |
-        echo Updating Kustomize image for remote language: "$REMOTE_LANGUAGE_IMAGE_NAME"
-      - kustomize edit set image nvideo-remote-language-image-name-placeholder="$REMOTE_LANGUAGE_IMAGE_NAME"
-      - |
-        echo Updating Kustomize image for local graph: "$LOCAL_GRAPH_IMAGE_NAME"
-      - kustomize edit set image nvideo-local-graph-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
-
-  - name: push-infra-changes
-    image: alpine/git
-    depends_on:
-      - build-push-api
-      - build-push-web
-      - build-push-remote-transcription
-      - build-push-remote-language
-      - build-push-local-graph
-      - clone-infra
-      - update-infra
-    commands:
-      - cd nvideo-infra
-      - git checkout main
-      - git config user.email "drone@deeplerg.dev"
-      - git config user.name "Drone"
-      - git add .
-      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
-      - git push
-
-trigger:
-  branch:
-    - main
-  event:
-    include:
-      - promote
-      - rollback
-      # - push
-  target:
-    - production
-
-
----
-kind: pipeline
-type: kubernetes
-name: prod-build-only
-
-steps:
   - name: image-warmer-api
     image: gcr.io/kaniko-project/warmer:latest
     volumes:
@@ -285,16 +54,32 @@ steps:
       - --dockerfile=local_graph_service/Dockerfile
       - --cache-dir=/cache/images
 
-  - name: build-no-push-api
+  - name: build-push-api
     image: gcr.io/kaniko-project/executor:debug
-    volumes:
-      - name: warmer-cache
-        path: /cache
+    environment:
+      USERNAME:
+        from_secret: registry_username
+      PASSWORD:
+        from_secret: registry_password
+      REGISTRY:
+        from_secret: registry_address
     commands:
-      - echo "Building API service"
-      - /kaniko/executor
-        --no-push
-        --context="."
+      - COMMIT=${DRONE_COMMIT_SHA:0:8}
+      - RAW_BRANCH=${DRONE_BRANCH}
+      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
+      - TAG=$BRANCH-$COMMIT
+      - API_IMAGE_NAME=$REGISTRY/nvideo-api:$TAG
+
+      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
+      - |
+        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
+      - echo $JSON > "/kaniko/.docker/config.json"
+
+      - |
+        echo Building and pushing API service: $API_IMAGE_NAME
+      - /kaniko/executor 
+        --destination="$API_IMAGE_NAME" 
+        --context="." 
         --dockerfile="api_service/Dockerfile"
         --compressed-caching=false
         --cache=true
@@ -303,16 +88,32 @@ steps:
         --no-push-cache
         --cache-dir=/cache/images
 
-  - name: build-no-push-web
+  - name: build-push-web
     image: gcr.io/kaniko-project/executor:debug
-    volumes:
-      - name: warmer-cache
-        path: /cache
+    environment:
+      USERNAME:
+        from_secret: registry_username
+      PASSWORD:
+        from_secret: registry_password
+      REGISTRY:
+        from_secret: registry_address
     commands:
-      - echo "Building Web service"
-      - /kaniko/executor
-        --no-push
-        --context="."
+      - COMMIT=${DRONE_COMMIT_SHA:0:8}
+      - RAW_BRANCH=${DRONE_BRANCH}
+      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
+      - TAG=$BRANCH-$COMMIT
+      - WEB_IMAGE_NAME=$REGISTRY/nvideo-web:$TAG
+
+      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
+      - |
+        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
+      - echo $JSON > "/kaniko/.docker/config.json"
+
+      - |
+        echo Building and pushing Web service: "$WEB_IMAGE_NAME"
+      - /kaniko/executor 
+        --destination="$WEB_IMAGE_NAME" 
+        --context="." 
         --dockerfile="web_service/Dockerfile"
         --compressed-caching=false
         --cache=true
@@ -321,16 +122,35 @@ steps:
         --no-push-cache
         --cache-dir=/cache/images
 
-  - name: build-no-push-remote-transcription
+  - name: build-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
-    volumes:
-      - name: warmer-cache
-        path: /cache
+    depends_on:
+      - build-push-api
+      - build-push-web
+    environment:
+      USERNAME:
+        from_secret: registry_username
+      PASSWORD:
+        from_secret: registry_password
+      REGISTRY:
+        from_secret: registry_address
     commands:
-      - echo "Building remote transcription service"
-      - /kaniko/executor
-        --no-push
-        --context="."
+      - COMMIT=${DRONE_COMMIT_SHA:0:8}
+      - RAW_BRANCH=${DRONE_BRANCH}
+      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
+      - TAG=$BRANCH-$COMMIT
+      - IMAGE_NAME=$REGISTRY/nvideo-remote-transcription:$TAG
+
+      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
+      - |
+        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
+      - echo $JSON > "/kaniko/.docker/config.json"
+
+      - |
+        echo Building and pushing remote transcription service: "$IMAGE_NAME"
+      - /kaniko/executor 
+        --destination="$IMAGE_NAME" 
+        --context="." 
         --dockerfile="remote_transcription_service/Dockerfile"
         --compressed-caching=false
         --cache=true
@@ -339,16 +159,35 @@ steps:
         --no-push-cache
         --cache-dir=/cache/images
 
-  - name: build-no-push-remote-language
+  - name: build-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
-    volumes:
-      - name: warmer-cache
-        path: /cache
+    depends_on:
+      - build-push-api
+      - build-push-web
+    environment:
+      USERNAME:
+        from_secret: registry_username
+      PASSWORD:
+        from_secret: registry_password
+      REGISTRY:
+        from_secret: registry_address
     commands:
-      - echo "Building remote language service"
-      - /kaniko/executor
-        --no-push
-        --context="."
+      - COMMIT=${DRONE_COMMIT_SHA:0:8}
+      - RAW_BRANCH=${DRONE_BRANCH}
+      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
+      - TAG=$BRANCH-$COMMIT
+      - IMAGE_NAME=$REGISTRY/nvideo-remote-language:$TAG
+
+      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
+      - |
+        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
+      - echo $JSON > "/kaniko/.docker/config.json"
+
+      - |
+        echo Building and pushing remote language service: "$IMAGE_NAME"
+      - /kaniko/executor 
+        --destination="$IMAGE_NAME" 
+        --context="." 
         --dockerfile="remote_language_service/Dockerfile"
         --compressed-caching=false
         --cache=true
@@ -357,16 +196,35 @@ steps:
         --no-push-cache
         --cache-dir=/cache/images
 
-  - name: build-no-push-local-graph
+  - name: build-push-local-graph
     image: gcr.io/kaniko-project/executor:debug
-    volumes:
-      - name: warmer-cache
-        path: /cache
+    depends_on:
+      - build-push-api
+      - build-push-web
+    environment:
+      USERNAME:
+        from_secret: registry_username
+      PASSWORD:
+        from_secret: registry_password
+      REGISTRY:
+        from_secret: registry_address
     commands:
-      - echo "Building local graph service"
-      - /kaniko/executor
-        --no-push
-        --context="."
+      - COMMIT=${DRONE_COMMIT_SHA:0:8}
+      - RAW_BRANCH=${DRONE_BRANCH}
+      - BRANCH=$(echo $RAW_BRANCH | sed 's/[^a-zA-Z0-9]/-/g')
+      - TAG=$BRANCH-$COMMIT
+      - IMAGE_NAME=$REGISTRY/nvideo-local-graph:$TAG
+
+      - AUTH=$(echo -n $USERNAME:$PASSWORD | base64 -w 0)
+      - |
+        JSON="{ \"auths\": { \"$REGISTRY\": { \"auth\": \"$AUTH\" } } }"
+      - echo $JSON > "/kaniko/.docker/config.json"
+
+      - |
+        echo Building and pushing local graph service: "$IMAGE_NAME"
+      - /kaniko/executor 
+        --destination="$IMAGE_NAME" 
+        --context="." 
         --dockerfile="local_graph_service/Dockerfile"
         --compressed-caching=false
         --cache=true
@@ -375,10 +233,138 @@ steps:
         --no-push-cache
         --cache-dir=/cache/images
 
+  - name: clone-infra
+    image: alpine/git
+    commands:
+      - git clone https://github.com/Deeplerg/nvideo-infra
+
+  - name: update-infra
+    image: registry.k8s.io/kustomize/kustomize:v5.0.0
+    depends_on:
+      - clone-infra
+    environment:
+      REGISTRY:
+        from_secret: registry_address
+    commands:
+      - COMMIT=${DRONE_COMMIT_SHA:0:8}
+      - BRANCH=main
+      - TAG=$BRANCH-$COMMIT
+      - API_IMAGE_NAME="$REGISTRY/nvideo-api:$TAG"
+      - WEB_IMAGE_NAME="$REGISTRY/nvideo-web:$TAG"
+      - REMOTE_TRANSCRIPTION_IMAGE_NAME="$REGISTRY/nvideo-remote-transcription:$TAG"
+      - REMOTE_LANGUAGE_IMAGE_NAME="$REGISTRY/nvideo-remote-language:$TAG"
+      - LOCAL_GRAPH_IMAGE_NAME="$REGISTRY/nvideo-local-graph:$TAG"
+
+      - cd nvideo-infra/kustomization/prod
+
+      - |
+        echo Updating Kustomize image for API: "$API_IMAGE_NAME"
+      - kustomize edit set image nvideo-api-image-name-placeholder="$API_IMAGE_NAME"
+      - |
+        echo Updating Kustomize image for Web: "$WEB_IMAGE_NAME"
+      - kustomize edit set image nvideo-web-image-name-placeholder="$WEB_IMAGE_NAME"
+      - |
+        echo Updating Kustomize image for remote transcription: "$REMOTE_TRANSCRIPTION_IMAGE_NAME"
+      - kustomize edit set image nvideo-remote-transcription-image-name-placeholder="$REMOTE_TRANSCRIPTION_IMAGE_NAME"
+      - |
+        echo Updating Kustomize image for remote language: "$REMOTE_LANGUAGE_IMAGE_NAME"
+      - kustomize edit set image nvideo-remote-language-image-name-placeholder="$REMOTE_LANGUAGE_IMAGE_NAME"
+      - |
+        echo Updating Kustomize image for local graph: "$LOCAL_GRAPH_IMAGE_NAME"
+      - kustomize edit set image nvideo-local-graph-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
+
+#  - name: push-infra-changes
+#    image: alpine/git
+#    depends_on:
+#      - build-push-api
+#      - build-push-web
+#      - build-push-remote-transcription
+#      - build-push-remote-language
+#      - build-push-local-graph
+#      - clone-infra
+#      - update-infra
+#    commands:
+#      - cd nvideo-infra
+#      - git checkout main
+#      - git config user.email "drone@deeplerg.dev"
+#      - git config user.name "Drone"
+#      - git add .
+#      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
+#      - git push
+
 volumes:
   - name: warmer-cache
     claim:
       name: kaniko-warmer-pvc
+
+trigger:
+  branch:
+    - main
+  event:
+    include:
+      - promote
+      - rollback
+      # - push
+  target:
+    - production
+    - exp/cicd
+
+
+---
+kind: pipeline
+type: kubernetes
+name: prod-build-only
+
+steps:
+  - name: build-no-push-api
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building API service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="api_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-web
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building Web service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="web_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-remote-transcription
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building remote transcription service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="remote_transcription_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-remote-language
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building remote language service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="remote_language_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-local-graph
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building local graph service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="local_graph_service/Dockerfile"
+        --compressed-caching=false
 
 trigger:
   branch:

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -270,6 +270,16 @@ steps:
         --dockerfile="remote_language_service/Dockerfile"
         --compressed-caching=false
 
+  - name: build-no-push-local-graph
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building local graph service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="local_graph_service/Dockerfile"
+        --compressed-caching=false
+
 trigger:
   branch:
     - main

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -4,68 +4,8 @@ type: kubernetes
 name: prod-build-push
 
 steps:
-  - name: image-warmer-api
-    image: gcr.io/kaniko-project/warmer:latest
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
-      - --dockerfile=api_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-web
-    image: gcr.io/kaniko-project/warmer:latest
-    depends_on:
-      - image-warmer-api
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
-      - --dockerfile=web_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-remote-transcription
-    image: gcr.io/kaniko-project/warmer:latest
-    depends_on:
-      - image-warmer-web
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
-      - --dockerfile=remote_transcription_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-remote-language
-    image: gcr.io/kaniko-project/warmer:latest
-    depends_on:
-      - image-warmer-remote-transcription
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
-      - --dockerfile=remote_language_service/Dockerfile
-      - --cache-dir=/cache/images
-
-  - name: image-warmer-local-graph
-    image: gcr.io/kaniko-project/warmer:latest
-    depends_on:
-      - image-warmer-remote-language
-    volumes:
-      - name: warmer-cache
-        path: /cache
-    command:
-      - /kaniko/warmer
-      - --dockerfile=local_graph_service/Dockerfile
-      - --cache-dir=/cache/images
-
   - name: build-push-api
     image: gcr.io/kaniko-project/executor:debug
-    depends_on:
-      - image-warmer-api
     environment:
       USERNAME:
         from_secret: registry_username
@@ -73,9 +13,6 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
-    volumes:
-      - name: warmer-cache
-        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -98,14 +35,12 @@ steps:
         --cache=true
         --cache-copy-layers=false
         --cache-run-layers=true
-        --cache-dir=/cache/images
         --image-fs-extract-retry=5
         --image-download-retry=5
 
   - name: build-push-web
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - image-warmer-web
       - build-push-api
     environment:
       USERNAME:
@@ -114,9 +49,6 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
-    volumes:
-      - name: warmer-cache
-        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -139,14 +71,12 @@ steps:
         --cache=true
         --cache-copy-layers=false
         --cache-run-layers=true
-        --cache-dir=/cache/images
         --image-fs-extract-retry=5
         --image-download-retry=5
 
   - name: build-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - image-warmer-remote-transcription
       - build-push-web
     environment:
       USERNAME:
@@ -155,9 +85,6 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
-    volumes:
-      - name: warmer-cache
-        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -180,14 +107,12 @@ steps:
         --cache=true
         --cache-copy-layers=false
         --cache-run-layers=true
-        --cache-dir=/cache/images
         --image-fs-extract-retry=5
         --image-download-retry=5
 
   - name: build-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - image-warmer-remote-language
       - build-push-remote-transcription
     environment:
       USERNAME:
@@ -196,9 +121,6 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
-    volumes:
-      - name: warmer-cache
-        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -221,14 +143,12 @@ steps:
         --cache=true
         --cache-copy-layers=false
         --cache-run-layers=true
-        --cache-dir=/cache/images
         --image-fs-extract-retry=5
         --image-download-retry=5
 
   - name: build-push-local-graph
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - image-warmer-local-graph
       - build-push-remote-language
     environment:
       USERNAME:
@@ -237,9 +157,6 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
-    volumes:
-      - name: warmer-cache
-        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -262,7 +179,6 @@ steps:
         --cache=true
         --cache-copy-layers=false
         --cache-run-layers=true
-        --cache-dir=/cache/images
         --image-fs-extract-retry=5
         --image-download-retry=5
 
@@ -324,11 +240,6 @@ steps:
 #      - git add .
 #      - git commit -am "Update image tags" --author="Drone <drone@deeplerg.dev>" --allow-empty
 #      - git push
-
-volumes:
-  - name: warmer-cache
-    claim:
-      name: kaniko-warmer-pvc
 
 trigger:
   branch:

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -32,9 +32,6 @@ steps:
         --context="." 
         --dockerfile="api_service/Dockerfile"
         --compressed-caching=false
-        --cache=true
-        --cache-copy-layers=false
-        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 
@@ -68,9 +65,6 @@ steps:
         --context="." 
         --dockerfile="web_service/Dockerfile"
         --compressed-caching=false
-        --cache=true
-        --cache-copy-layers=false
-        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 
@@ -104,9 +98,6 @@ steps:
         --context="." 
         --dockerfile="remote_transcription_service/Dockerfile"
         --compressed-caching=false
-        --cache=true
-        --cache-copy-layers=false
-        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 
@@ -140,9 +131,6 @@ steps:
         --context="." 
         --dockerfile="remote_language_service/Dockerfile"
         --compressed-caching=false
-        --cache=true
-        --cache-copy-layers=false
-        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 
@@ -176,9 +164,6 @@ steps:
         --context="." 
         --dockerfile="local_graph_service/Dockerfile"
         --compressed-caching=false
-        --cache=true
-        --cache-copy-layers=false
-        --cache-run-layers=true
         --image-fs-extract-retry=5
         --image-download-retry=5
 

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -230,45 +230,45 @@ type: kubernetes
 name: prod-build-only
 
 steps:
-#  - name: build-no-push-api
-#    image: gcr.io/kaniko-project/executor:debug
-#    commands:
-#      - echo "Building API service"
-#      - /kaniko/executor
-#        --no-push
-#        --context="."
-#        --dockerfile="api_service/Dockerfile"
-#        --compressed-caching=false
-#
-#  - name: build-no-push-web
-#    image: gcr.io/kaniko-project/executor:debug
-#    commands:
-#      - echo "Building Web service"
-#      - /kaniko/executor
-#        --no-push
-#        --context="."
-#        --dockerfile="web_service/Dockerfile"
-#        --compressed-caching=false
-#
-#  - name: build-no-push-remote-transcription
-#    image: gcr.io/kaniko-project/executor:debug
-#    commands:
-#      - echo "Building remote transcription service"
-#      - /kaniko/executor
-#        --no-push
-#        --context="."
-#        --dockerfile="remote_transcription_service/Dockerfile"
-#        --compressed-caching=false
-#
-#  - name: build-no-push-remote-language
-#    image: gcr.io/kaniko-project/executor:debug
-#    commands:
-#      - echo "Building remote language service"
-#      - /kaniko/executor
-#        --no-push
-#        --context="."
-#        --dockerfile="remote_language_service/Dockerfile"
-#        --compressed-caching=false
+  - name: build-no-push-api
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building API service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="api_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-web
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building Web service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="web_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-remote-transcription
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building remote transcription service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="remote_transcription_service/Dockerfile"
+        --compressed-caching=false
+
+  - name: build-no-push-remote-language
+    image: gcr.io/kaniko-project/executor:debug
+    commands:
+      - echo "Building remote language service"
+      - /kaniko/executor
+        --no-push
+        --context="."
+        --dockerfile="remote_language_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-no-push-local-graph
     image: gcr.io/kaniko-project/executor:debug

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -4,7 +4,7 @@ type: kubernetes
 name: prod-build-push
 
 steps:
-  - name: image-warmer
+  - name: image-warmer-api
     image: gcr.io/kaniko-project/warmer:latest
     volumes:
       - name: warmer-cache
@@ -12,16 +12,52 @@ steps:
     command:
       - /kaniko/warmer
       - --dockerfile=api_service/Dockerfile
+      - --cache-dir=/cache/images
+
+  - name: image-warmer-web
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer
       - --dockerfile=web_service/Dockerfile
+      - --cache-dir=/cache/images
+
+  - name: image-warmer-remote-transcription
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer
       - --dockerfile=remote_transcription_service/Dockerfile
+      - --cache-dir=/cache/images
+
+  - name: image-warmer-remote-language
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer
       - --dockerfile=remote_language_service/Dockerfile
+      - --cache-dir=/cache/images
+
+  - name: image-warmer-local-graph
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer
       - --dockerfile=local_graph_service/Dockerfile
       - --cache-dir=/cache/images
 
   - name: build-push-api
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - image-warmer
+      - image-warmer-api
     environment:
       USERNAME:
         from_secret: registry_username
@@ -57,7 +93,7 @@ steps:
   - name: build-push-web
     image: gcr.io/kaniko-project/executor:debug
     depends_on:
-      - image-warmer
+      - image-warmer-web
     environment:
       USERNAME:
         from_secret: registry_username
@@ -95,7 +131,7 @@ steps:
     depends_on:
       - build-push-api
       - build-push-web
-      - image-warmer
+      - image-warmer-remote-transcription
     environment:
       USERNAME:
         from_secret: registry_username
@@ -133,7 +169,7 @@ steps:
     depends_on:
       - build-push-api
       - build-push-web
-      - image-warmer
+      - image-warmer-remote-language
     environment:
       USERNAME:
         from_secret: registry_username
@@ -171,7 +207,7 @@ steps:
     depends_on:
       - build-push-api
       - build-push-web
-      - image-warmer
+      - image-warmer-local-graph
     environment:
       USERNAME:
         from_secret: registry_username

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -235,29 +235,45 @@ type: kubernetes
 name: prod-build-only
 
 steps:
-  - name: image-warmer
+  - name: image-warmer-api
     image: gcr.io/kaniko-project/warmer:latest
     volumes:
       - name: warmer-cache
         path: /cache
-    commands:
-      - echo 12345
-      - sleep 1h
-      - /kaniko/warmer 
-        --dockerfile="api_service/Dockerfile"
-        --cache-dir="/cache/images"
-      - /kaniko/warmer 
-        --dockerfile="web_service/Dockerfile"
-        --cache-dir="/cache/images"
-      - /kaniko/warmer 
-        --dockerfile="remote_transcription_service/Dockerfile"
-        --cache-dir="/cache/images"
-      - /kaniko/warmer 
-        --dockerfile="remote_language_service/Dockerfile"
-        --cache-dir="/cache/images"
-      - /kaniko/warmer 
-        --dockerfile="local_graph_service/Dockerfile"
-        --cache-dir="/cache/images"
+    command:
+      - /kaniko/warmer --dockerfile="api_service/Dockerfile" --cache-dir="/cache/images"
+
+  - name: image-warmer-web
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer --dockerfile="web_service/Dockerfile" --cache-dir="/cache/images"
+
+  - name: image-warmer-remote-transcription
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer --dockerfile="remote_transcription_service/Dockerfile" --cache-dir="/cache/images"
+
+  - name: image-warmer-remote-language
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer --dockerfile="remote_language_service/Dockerfile" --cache-dir="/cache/images"
+
+  - name: image-warmer-local-graph
+    image: gcr.io/kaniko-project/warmer:latest
+    volumes:
+      - name: warmer-cache
+        path: /cache
+    command:
+      - /kaniko/warmer --dockerfile="local_graph_service/Dockerfile" --cache-dir="/cache/images"
 
   - name: build-no-push-api
     image: gcr.io/kaniko-project/executor:debug

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -31,6 +31,7 @@ steps:
         --destination="$API_IMAGE_NAME" 
         --context="." 
         --dockerfile="api_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-push-web
     image: gcr.io/kaniko-project/executor:debug
@@ -59,6 +60,7 @@ steps:
         --destination="$WEB_IMAGE_NAME" 
         --context="." 
         --dockerfile="web_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-push-remote-transcription
     image: gcr.io/kaniko-project/executor:debug
@@ -90,6 +92,7 @@ steps:
         --destination="$IMAGE_NAME" 
         --context="." 
         --dockerfile="remote_transcription_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-push-remote-language
     image: gcr.io/kaniko-project/executor:debug
@@ -121,6 +124,7 @@ steps:
         --destination="$IMAGE_NAME" 
         --context="." 
         --dockerfile="remote_language_service/Dockerfile"
+        --compressed-caching=false
 
   - name: build-push-local-graph
     image: gcr.io/kaniko-project/executor:debug
@@ -152,6 +156,7 @@ steps:
         --destination="$IMAGE_NAME" 
         --context="." 
         --dockerfile="local_graph_service/Dockerfile"
+        --compressed-caching=false
 
   - name: clone-infra
     image: alpine/git
@@ -185,13 +190,13 @@ steps:
       - kustomize edit set image nvideo-web-image-name-placeholder="$WEB_IMAGE_NAME"
       - |
         echo Updating Kustomize image for remote transcription: "$REMOTE_TRANSCRIPTION_IMAGE_NAME"
-      - kustomize edit set image nvideo-web-image-name-placeholder="$REMOTE_TRANSCRIPTION_IMAGE_NAME"
+      - kustomize edit set image nvideo-remote-transcription-image-name-placeholder="$REMOTE_TRANSCRIPTION_IMAGE_NAME"
       - |
         echo Updating Kustomize image for remote language: "$REMOTE_LANGUAGE_IMAGE_NAME"
-      - kustomize edit set image nvideo-web-image-name-placeholder="$REMOTE_LANGUAGE_IMAGE_NAME"
+      - kustomize edit set image nvideo-remote-language-image-name-placeholder="$REMOTE_LANGUAGE_IMAGE_NAME"
       - |
         echo Updating Kustomize image for local graph: "$LOCAL_GRAPH_IMAGE_NAME"
-      - kustomize edit set image nvideo-web-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
+      - kustomize edit set image nvideo-local-graph-image-name-placeholder="$LOCAL_GRAPH_IMAGE_NAME"
 
   - name: push-infra-changes
     image: alpine/git

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -241,7 +241,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile=api_service/Dockerfile --cache-dir=/cache/images
+      - "/kaniko/warmer --dockerfile=api_service/Dockerfile --cache-dir=/cache/images"
 
   - name: image-warmer-web
     image: gcr.io/kaniko-project/warmer:latest
@@ -249,7 +249,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile=web_service/Dockerfile --cache-dir=/cache/images
+      - "/kaniko/warmer --dockerfile=web_service/Dockerfile --cache-dir=/cache/images"
 
   - name: image-warmer-remote-transcription
     image: gcr.io/kaniko-project/warmer:latest
@@ -257,7 +257,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile=remote_transcription_service/Dockerfile --cache-dir=/cache/images
+      - "/kaniko/warmer --dockerfile=remote_transcription_service/Dockerfile --cache-dir=/cache/images"
 
   - name: image-warmer-remote-language
     image: gcr.io/kaniko-project/warmer:latest
@@ -265,7 +265,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile=remote_language_service/Dockerfile --cache-dir=/cache/images
+      - "/kaniko/warmer --dockerfile=remote_language_service/Dockerfile --cache-dir=/cache/images"
 
   - name: image-warmer-local-graph
     image: gcr.io/kaniko-project/warmer:latest
@@ -273,7 +273,7 @@ steps:
       - name: warmer-cache
         path: /cache
     command:
-      - /kaniko/warmer --dockerfile=local_graph_service/Dockerfile --cache-dir=/cache/images
+      - "/kaniko/warmer --dockerfile=local_graph_service/Dockerfile --cache-dir=/cache/images"
 
   - name: build-no-push-api
     image: gcr.io/kaniko-project/executor:debug

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -240,8 +240,8 @@ steps:
     volumes:
       - name: warmer-cache
         path: /cache
+    entrypoint: /kaniko/warmer
     command:
-      - /kaniko/warmer
       - --dockerfile=api_service/Dockerfile
       - --cache-dir=/cache/images
 

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -73,6 +73,9 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -111,6 +114,9 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -149,6 +155,9 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -187,6 +196,9 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}
@@ -225,6 +237,9 @@ steps:
         from_secret: registry_password
       REGISTRY:
         from_secret: registry_address
+    volumes:
+      - name: warmer-cache
+        path: /cache
     commands:
       - COMMIT=${DRONE_COMMIT_SHA:0:8}
       - RAW_BRANCH=${DRONE_BRANCH}

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -20,6 +20,8 @@ steps:
 
   - name: build-push-api
     image: gcr.io/kaniko-project/executor:debug
+    depends_on:
+      - image-warmer
     environment:
       USERNAME:
         from_secret: registry_username
@@ -54,6 +56,8 @@ steps:
 
   - name: build-push-web
     image: gcr.io/kaniko-project/executor:debug
+    depends_on:
+      - image-warmer
     environment:
       USERNAME:
         from_secret: registry_username
@@ -91,6 +95,7 @@ steps:
     depends_on:
       - build-push-api
       - build-push-web
+      - image-warmer
     environment:
       USERNAME:
         from_secret: registry_username
@@ -128,6 +133,7 @@ steps:
     depends_on:
       - build-push-api
       - build-push-web
+      - image-warmer
     environment:
       USERNAME:
         from_secret: registry_username
@@ -165,6 +171,7 @@ steps:
     depends_on:
       - build-push-api
       - build-push-web
+      - image-warmer
     environment:
       USERNAME:
         from_secret: registry_username


### PR DESCRIPTION
Python is an interpreted language, so packing the .py files into containers doesn't help detect errors.